### PR TITLE
Ability to show "No Response" for offline devices on Homekit

### DIFF
--- a/Cmd4Accessory.js
+++ b/Cmd4Accessory.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const moment = require( "moment" );
+const fs = require('fs');
 
 // Settings, Globals and Constants
 let settings = require( "./cmd4Settings" );

--- a/Cmd4Accessory.js
+++ b/Cmd4Accessory.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const moment = require( "moment" );
-const fs = require('fs');
 
 // Settings, Globals and Constants
 let settings = require( "./cmd4Settings" );

--- a/cmd4Constants.js
+++ b/cmd4Constants.js
@@ -149,6 +149,6 @@ var cmd4Constants = {
 
 
    // Static Messages
-   DBUSY:                          "Perhaps your device is busy?"
+   DBUSY:                          "Perhaps your device is busy or offine!"
 };
 module.exports = cmd4Constants;


### PR DESCRIPTION
---
name: Pull Request
about: Resolve an issue or add an improvement to cmd4.
title: "[Pull Request]Ability to show "No Response" for offline devices on Homekit"
labels: pull-request
assignees: ztalbot2000

---

<!-- Provide a general summary in the Title above -->
Added capability to homebridge-cmd4 to show "No Response" on Homekit when CMD4 `getValue` requests return a non-zero error code.

**Is your pull request related to a problem? Please describe:**
<!-- A clear and concise description of what the problem is. E.g. John there needs to be a button to buy you a coffee. -->
Current version (6.3.0) of homebridge-cmd4 is showing all devices on Homekit as online devices eventhough some of the devices are offline or not available. Device which is offline or simply not available should show "No Response" on Homekit so that Homekit users will know very quickly that that particular device is not unavailable to them and needed some attention.

**Describe the solution you'd have implemented:**
<!-- A clear and concise description of what you your pull request is for. Explain the technical solution you have provided and how it addresses the issue. -->
Coded in some logic in 2 places:
1. Scripted a simple logic in `qGetValue` function in `Cmd4PrioirtyPollingQueue.js` such that if AdvAir.sh returns a non-zero error code from Cmd4 `getValue` request, an empty file `cmd4Accessory-<displayName>.offline` will be created in homebridge home directory as a flag to indicate that the device is likely offline or simply not unavailable. If AdvAir.sh returns an error code of 0, the flag file `cmd4Accessory-<displayName>.offline` will be removed if presence.
2. Scripted also some simple logic in `priorityGetValue` function also in `Cmd4PriorityPollingQueue.js` to check for the presence of the file `cmd4Accessory-<displayName>.offline`, if found, set the error code to 1, otherwise leave the error code as 0.  A non-zero error code in callback function within `priorityGetValue` function seem to stop the communication between Homekit and Cmd4, and the offline device will show the word "No Response" with a white icon on the Homekit tile.

**Do your changes pass unit testing ( npm run test ) :**
- [x] Yes the unit test results are the same as the official version 6.3.0.  Tested also successfully on my E-zone system with a simulated offline device and a myPlace system with 6 offline devices (one of the light modules has blown awaiting replacement).
- [ ] No

**Do your changes pass lint testing ( npm run lint ) :**
- [x] Yes
- [ ] No

**Additional context:**
<!-- Add any other context or screenshots about the pull request here. -->

Shown below is a screenshot of my E-zone system with simulated offline `Bed 5 Zone` device.  To simulate an offline device, I just put in a dummy "lightbulb" config with the `dispayName` and `name` as `Bed 5 Zone` and polling for both `On` and `Brightness` characteristics.  There is no info for that "offline" device in getSystemData.  This is exactly what happen to the myPlace system.  When a module dies, all the info pertaining to the devices controlled by the module disappeared from the getSystemData.

![image](https://user-images.githubusercontent.com/96530237/219679182-b4a22cbb-b796-4a54-9e13-08e1a3273730.png)

<!-- Click the "Preview" tab before you submit to ensure the formatting is correct. -->
